### PR TITLE
Remove dbg statement

### DIFF
--- a/crates/bicycle_compiler/src/small_angle.rs
+++ b/crates/bicycle_compiler/src/small_angle.rs
@@ -120,8 +120,7 @@ pub(crate) fn run_gridsynth(
     angle: AnglePrecision,
     accuracy: AnglePrecision,
 ) -> Result<String, io::Error> {
-    dbg!(angle);
-    dbg!(accuracy);
+    debug!("Running gridsynth with angle: {angle} and accuracy: {accuracy}");
 
     #[cfg(not(feature = "rsgridsynth"))]
     {


### PR DESCRIPTION
Replaces `dbg!` statements with a single `debug!` so that the angle and accuracy are not always printed.